### PR TITLE
Anonymous: Add configurable device limit

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -197,6 +197,7 @@ export interface GrafanaConfig {
   theme: GrafanaTheme;
   theme2: GrafanaTheme2;
   anonymousEnabled: boolean;
+  anonymousDeviceLimit: number | undefined;
   featureToggles: FeatureToggles;
   licenseInfo: LicenseInfo;
   http2Enabled: boolean;

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -94,6 +94,7 @@ export class GrafanaBootConfig implements GrafanaConfig {
   theme2: GrafanaTheme2;
   featureToggles: FeatureToggles = {};
   anonymousEnabled = false;
+  anonymousDeviceLimit = undefined;
   licenseInfo: LicenseInfo = {} as LicenseInfo;
   rendererAvailable = false;
   rendererVersion = '';

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -192,6 +192,7 @@ type FrontendSettingsDTO struct {
 
 	FeatureToggles                   map[string]bool                `json:"featureToggles"`
 	AnonymousEnabled                 bool                           `json:"anonymousEnabled"`
+	AnonymousDeviceLimit             int64                          `json:"anonymousDeviceLimit"`
 	RendererAvailable                bool                           `json:"rendererAvailable"`
 	RendererVersion                  string                         `json:"rendererVersion"`
 	SecretsManagerPluginEnabled      bool                           `json:"secretsManagerPluginEnabled"`

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -195,6 +195,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 
 		FeatureToggles:                   hs.Features.GetEnabled(c.Req.Context()),
 		AnonymousEnabled:                 hs.Cfg.AnonymousEnabled,
+		AnonymousDeviceLimit:             hs.Cfg.AnonymousDeviceLimit,
 		RendererAvailable:                hs.RenderService.IsAvailable(c.Req.Context()),
 		RendererVersion:                  hs.RenderService.Version(),
 		SecretsManagerPluginEnabled:      secretsManagerPluginEnabled,

--- a/pkg/services/anonymous/anonimpl/api/api.go
+++ b/pkg/services/anonymous/anonimpl/api/api.go
@@ -15,9 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-const (
-	thirtyDays = 30 * 24 * time.Hour
-)
+const anonymousDeviceExpiration = 30 * 24 * time.Hour
 
 type deviceDTO struct {
 	anonstore.Device
@@ -70,7 +68,7 @@ func (api *AnonDeviceServiceAPI) RegisterAPIEndpoints() {
 //	404: notFoundError
 //	500: internalServerError
 func (api *AnonDeviceServiceAPI) ListDevices(c *contextmodel.ReqContext) response.Response {
-	fromTime := time.Now().Add(-thirtyDays)
+	fromTime := time.Now().Add(-anonymousDeviceExpiration)
 	toTime := time.Now()
 
 	devices, err := api.store.ListDevices(c.Req.Context(), &fromTime, &toTime)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -372,6 +372,7 @@ type Cfg struct {
 	AnonymousOrgName     string
 	AnonymousOrgRole     string
 	AnonymousHideVersion bool
+	AnonymousDeviceLimit int64
 
 	DateFormats DateFormats
 
@@ -1646,10 +1647,12 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 	readAuthGithubSettings(cfg)
 
 	// anonymous access
-	cfg.AnonymousEnabled = iniFile.Section("auth.anonymous").Key("enabled").MustBool(false)
-	cfg.AnonymousOrgName = valueAsString(iniFile.Section("auth.anonymous"), "org_name", "")
-	cfg.AnonymousOrgRole = valueAsString(iniFile.Section("auth.anonymous"), "org_role", "")
-	cfg.AnonymousHideVersion = iniFile.Section("auth.anonymous").Key("hide_version").MustBool(false)
+	anonSection := iniFile.Section("auth.anonymous")
+	cfg.AnonymousEnabled = anonSection.Key("enabled").MustBool(false)
+	cfg.AnonymousOrgName = valueAsString(anonSection, "org_name", "")
+	cfg.AnonymousOrgRole = valueAsString(anonSection, "org_role", "")
+	cfg.AnonymousHideVersion = anonSection.Key("hide_version").MustBool(false)
+	cfg.AnonymousDeviceLimit = anonSection.Key("device_limit").MustInt64(0)
 
 	// basic auth
 	authBasic := iniFile.Section("auth.basic")


### PR DESCRIPTION
This PR adds device limiter functionality to the anonymous access system.

## Summary
- Add configurable device limit for anonymous users  
- Implement device limit checking in database store
- Break authentication if limit is reached
- Add frontend configuration for device limits

## Changes
- Add AnonymousDeviceLimit configuration option
- Implement ErrDeviceLimitReached error handling  
- Update database store to check device limits before creating new devices
- Add device limit validation in authentication client
- Expose device limit setting in frontend configuration

## Technical Details
The device limit is enforced at the database level by:
1. Counting existing devices within the expiration window
2. If limit exceeded, only allowing updates to existing devices  
3. Returning ErrDeviceLimitReached error for new device creation attempts
4. Authentication client handles the error and blocks anonymous access

## Configuration
Add to grafana.ini:
```ini
[auth.anonymous]
device_limit = 100
```

Co-authored-by: Eric Leijonmarck <eric.leijonmarck@gmail.com>